### PR TITLE
feat(Resolvers): Add Antd v5 resolver.

### DIFF
--- a/src/core/resolvers/antd-v5.ts
+++ b/src/core/resolvers/antd-v5.ts
@@ -1,0 +1,10 @@
+import type { BaseResolverOptions } from '../../types'
+import { createResolver } from './createResolver'
+
+interface Options extends BaseResolverOptions { }
+
+export const AntdV5Resolver = createResolver<Options>({
+  module: 'antd',
+  prefix: 'Ant',
+  style: false,
+})


### PR DESCRIPTION
适配 Antd v5 的版本。

ps: 给原来的 AntdResolver 增加一个 `version` 的选项可能更好点，但是貌似逻辑都在通用的 `CreateResolver` 方法里，看有没有更好的办法吧。